### PR TITLE
Generate CLI was broken for me under ruby 1.9.1-p129

### DIFF
--- a/lib/ticketmaster/cli/commands/generate.rb
+++ b/lib/ticketmaster/cli/commands/generate.rb
@@ -3,11 +3,12 @@ def generate(options)
   if ARGV.length == 0
     ARGV << '--help'
   else
-    options[:provider] = ARGV.shift
-    if options[:provider].first == '_'
-      options[:provider][0] = ''
+    provider_name = ARGV.shift
+    if provider_name.start_with? '_'
+      options[:provider] = provider_name[1..-1]
       options[:provider_dir] = options[:provider]
     else
+      options[:provider] = provider_name
       options[:provider_dir] = 'ticketmaster-' + options[:provider]
     end
   end

--- a/spec/ticketmaster-cli_spec.rb
+++ b/spec/ticketmaster-cli_spec.rb
@@ -3,6 +3,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'spec'
 require 'spec/autorun'
 
+require 'fileutils'
+
 Spec::Runner.configure do |config| end
 # Tests for the cli
 # I'm not quite sure what the most effective way to test this is...
@@ -30,6 +32,31 @@ describe "Ticketmaster CLI" do
   
   it "should be able to open up a console" do
     pending
+  end
+  
+  describe :generate do
+    it "should generate provider skeleton w/o runtime errors" do
+      provider_name = "test-provider"
+      expected_name = "ticketmaster-#{provider_name}"
+      begin
+        generate = `#{@ticket} generate #{provider_name}`
+        $?.should == 0
+        File.exists?(expected_name).should == true
+      ensure
+        FileUtils.remove_dir(expected_name) if File.exists? expected_name
+      end
+    end  
+    
+    it "should not prefix 'ticketmaster' when not asked to" do
+      provider_name = "test-provider"
+      begin
+        generate = `#{@ticket} generate _#{provider_name}`
+        $?.should == 0
+        File.exists?(provider_name).should == true
+      ensure
+        FileUtils.remove_dir(provider_name) if File.exists? provider_name
+      end
+    end
   end
   
 end


### PR DESCRIPTION
```
$ tm generate foo
/Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/gems/ticketmaster-0.4.8/lib/ticketmaster/cli/commands/generate.rb:7:in `generate': undefined method `first' for "foo":String (NoMethodError)
from /Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/gems/ticketmaster-0.4.8/bin/../lib/ticketmaster/cli/init.rb:73:in `<top (required)>'
from /Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/gems/ticketmaster-0.4.8/bin/tm:6:in `require'
from /Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/gems/ticketmaster-0.4.8/bin/tm:6:in `<top (required)>'
from /Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/bin/tm:19:in `load'
from /Users/brian/.rvm/gems/ruby-1.9.1-p129@ticketmaster/bin/tm:19:in `<main>'
```

`String` doesn't include `Enumerable` in ruby 1.9.  We can use `String.start_with?` instead.
