### PR TITLE
Reflection added to 'This method must be reimplemented in the provider' exception messages

### DIFF
--- a/lib/ticketmaster.rb
+++ b/lib/ticketmaster.rb
@@ -17,6 +17,7 @@ end
   provider
   exception
   dummy/dummy.rb
+  tester/tester.rb
 }.each {|lib| require File.dirname(__FILE__) + '/ticketmaster/' + lib }
 
 

--- a/lib/ticketmaster/comment.rb
+++ b/lib/ticketmaster/comment.rb
@@ -68,7 +68,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.new self::API.find(id, :params => {:project_id => project_id, :ticket_id => ticket_id})
         else
-          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       

--- a/lib/ticketmaster/comment.rb
+++ b/lib/ticketmaster/comment.rb
@@ -68,7 +68,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.new self::API.find(id, :params => {:project_id => project_id, :ticket_id => ticket_id})
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be reimplemented in the provider")
         end
       end
       
@@ -79,7 +79,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.search(project_id, ticket_id, attributes)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -89,7 +89,7 @@ module TicketMaster::Provider
           comments = self::API.find(:all, :params => {:project_id => project_id, :ticket_id => ticket_id}).collect { |comment| self.new comment }
           search_by_attribute(comments, options, limit)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
     end

--- a/lib/ticketmaster/common.rb
+++ b/lib/ticketmaster/common.rb
@@ -12,7 +12,7 @@ module TicketMaster::Provider
             something.save
             self.new something
           else
-            raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+            raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
           end
         end
       end
@@ -58,7 +58,7 @@ module TicketMaster::Provider
           end
           something.save if changes > 0
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.class.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -68,7 +68,7 @@ module TicketMaster::Provider
         if @system_data and @system_data[:client] and @system_data[:client].respond_to?(:destroy)
           return @system_data[:client].destroy
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.class.name}::#{this_method} method must be implemented by the provider")
         end
       end
       

--- a/lib/ticketmaster/helper.rb
+++ b/lib/ticketmaster/helper.rb
@@ -16,7 +16,7 @@ module TicketMaster::Provider
         options.insert(at_index, symbol) if options[at_index].is_a?(Hash)
         api.find(*options)
       else
-        raise TicketMaster::Exception.new("#{Helper.name}::#{this_method} method must be reimplemented in the provider")
+        raise TicketMaster::Exception.new("#{Helper.name}::#{this_method} method must be implemented by the provider")
       end
     end
     

--- a/lib/ticketmaster/helper.rb
+++ b/lib/ticketmaster/helper.rb
@@ -2,6 +2,13 @@ module TicketMaster::Provider
   # Contains a series of helper methods
   module Helper
   
+    # Current method name reflection
+    # http://www.ruby-forum.com/topic/75258#895630
+    # Call when raising 'implemented by the provider' exceptions
+    def this_method
+      caller[0][/`([^']*)'/, 1]
+    end
+    
     # A helper method for easy finding
     def easy_finder(api, symbol, options, at_index = 0)
       if api.is_a? Class
@@ -9,7 +16,7 @@ module TicketMaster::Provider
         options.insert(at_index, symbol) if options[at_index].is_a?(Hash)
         api.find(*options)
       else
-        raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+        raise TicketMaster::Exception.new("#{Helper.name}::#{this_method} method must be reimplemented in the provider")
       end
     end
     

--- a/lib/ticketmaster/project.rb
+++ b/lib/ticketmaster/project.rb
@@ -88,7 +88,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.new self::API.find(id)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -99,7 +99,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.search(attributes)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -109,7 +109,7 @@ module TicketMaster::Provider
           projects = self::API.find(:all).collect { |project| self.new project }
           search_by_attribute(projects, options, limit)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
 

--- a/lib/ticketmaster/tester/comment.rb
+++ b/lib/ticketmaster/tester/comment.rb
@@ -1,0 +1,18 @@
+module TicketMaster::Provider
+  module Tester
+    # This is the Comment class for the Tester provider
+    class Comment < TicketMaster::Provider::Base::Comment
+                 
+      # You don't need to define an initializer, this is only here to initialize tester data
+      def initialize(project_id, ticket_id, *options)
+        data = {:id => rand(1000), :status => ['lol', 'rofl', 'lmao', 'lamo', 'haha', 'heh'][rand(6)],
+          :priority => rand(10), :summary => 'Tickets ticket ticket ticket', :resolution => false,
+          :created_at => Time.now, :updated_at => Time.now, :description => 'Ticket ticket ticket ticket laughing',
+          :assignee => 'lol-man'}
+        @system = :tester
+        super(data.merge(options.first || {}))
+      end
+      
+    end
+  end
+end

--- a/lib/ticketmaster/tester/project.rb
+++ b/lib/ticketmaster/tester/project.rb
@@ -1,0 +1,19 @@
+module TicketMaster::Provider
+  module Tester
+    # This is the Project class for the Tester provider
+    class Project < TicketMaster::Provider::Base::Project
+            
+      # You should define @system and @system_data here.
+      # The data stuff is just to initialize fake data. In a real provider, you would use the API
+      # to grab the information and then initialize based on that info.
+      # @system_data would hold the API's model/instance for reference
+      def initialize(*options)
+        data = {:id => rand(1000).to_i, :name => 'Tester', :description => 'Mock!-ing Bird',
+          :created_at => Time.now, :updated_at => Time.now}
+        @system = :tester
+        super(data.merge(options.first || {}))
+      end
+      
+    end
+  end
+end

--- a/lib/ticketmaster/tester/tester.rb
+++ b/lib/ticketmaster/tester/tester.rb
@@ -1,0 +1,28 @@
+module TicketMaster::Provider
+  # This is the Tester Provider
+  #
+  # It doesn't really do anything, it exists in order to test the basic functionality of ticketmaster
+  # and to provide an example the basics of what is to be expected from the providers.
+  # 
+  # Note that the initial provider name is a module rather than a class. TicketMaster.new
+  # extends on an instance-based fashion. If you would rather initialize using code that is 
+  # closer to:
+  # 
+  #    TicketMaster::Provider::Tester.new(authentication)
+  #
+  # You will have to do a little magic trick and define new on the provider as a wrapper
+  # around the TicketMaster.new call.
+  module Tester
+    include TicketMaster::Provider::Base
+    # An example of what to do if you would like to do TicketMaster::Provider::Tester.new(...)
+    # rather than TicketMaster.new(:tester, ...)
+    def self.new(authentication = {})
+      TicketMaster.new(:tester, authentication)
+      # maybe do some other stuff
+    end
+  end
+end
+
+%w| project ticket comment |.each do |f|
+  require File.dirname(__FILE__) + '/' + f +'.rb'
+end

--- a/lib/ticketmaster/tester/ticket.rb
+++ b/lib/ticketmaster/tester/ticket.rb
@@ -1,0 +1,19 @@
+module TicketMaster::Provider
+  module Tester
+    # The Tester Provider's Ticket class
+    class Ticket < TicketMaster::Provider::Base::Ticket
+      @system = :tester
+      
+      # You don't need to define an initializer, this is only here to initialize tester data
+      def initialize(project_id, *options)
+        data = {:id => rand(1000), :status => ['lol', 'rofl', 'lmao', 'lamo', 'haha', 'heh'][rand(6)],
+          :priority => rand(10), :summary => 'Tickets ticket ticket ticket', :resolution => false,
+          :created_at => Time.now, :updated_at => Time.now, :description => 'Ticket ticket ticket ticket laughing',
+          :assignee => 'lol-man', :project_id => project_id}
+        @system = :tester
+        super(data.merge(options.first || {}))
+      end
+      
+    end
+  end
+end

--- a/lib/ticketmaster/ticket.rb
+++ b/lib/ticketmaster/ticket.rb
@@ -90,7 +90,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.new self::API.find(ticket_id, :params => {:project_id => project_id})
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -101,7 +101,7 @@ module TicketMaster::Provider
         if self::API.is_a? Class
           self.search(project_id, attributes)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
       
@@ -111,7 +111,7 @@ module TicketMaster::Provider
           tickets = self::API.find(:all, :params => {:project_id => project_id}).collect { |ticket| self.new ticket }
           search_by_attribute(tickets, options, limit)
         else
-          raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+          raise TicketMaster::Exception.new("#{self.name}::#{this_method} method must be implemented by the provider")
         end
       end
 
@@ -141,12 +141,12 @@ module TicketMaster::Provider
       #
       # On success it should return true, otherwise false
       def close(*options)
-        raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+        raise TicketMaster::Exception.new("#{self.class.name}::#{this_method} method must be implemented by the provider")
       end
       
       # Reload this ticket
       def reload!(*options)
-        raise TicketMaster::Exception.new("This method must be reimplemented in the provider")
+        raise TicketMaster::Exception.new("#{self.class.name}::#{this_method} method must be implemented by the provider")
       end
 
     end

--- a/spec/ticketmaster-exception_spec.rb
+++ b/spec/ticketmaster-exception_spec.rb
@@ -1,0 +1,123 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'rubygems'
+require 'rspec'
+require 'ticketmaster'
+
+describe "Ticketmaster Exception Messages" do
+  
+  before(:all) do
+    @exception = TicketMaster::Exception
+  end
+  
+  before(:each) do
+    @ticketmaster = TicketMaster.new(:tester, {})
+  end
+  
+  describe "TicketMaster::Provider::Helper" do
+    it "easy_finder method raises correct exception" do
+      msg = "TicketMaster::Provider::Helper::easy_finder method must be implemented by the provider"
+      lambda { @ticketmaster.easy_finder(1, :test, {}) }.should raise_error(@exception, msg)
+    end
+  end
+  
+  describe "TicketMaster::Provider::Tester::Project" do
+    it "find_by_id method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Project::find_by_id method must be implemented by the provider"
+      lambda { @ticketmaster.project([1]) }.should raise_error(@exception, msg)
+    end    
+    it "find_by_attributes method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Project::find_by_attributes method must be implemented by the provider"
+      lambda { @ticketmaster.project.find :all, :name => 'Test Project' }.should raise_error(@exception, msg)
+    end    
+    it "search method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Project::search method must be implemented by the provider"
+      lambda { @ticketmaster.project.search :tag => 'testing' }.should raise_error(@exception, msg)
+    end    
+    it "create method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Project::create method must be implemented by the provider"
+      lambda { @ticketmaster.project.create :name => 'Foo Bar' }.should raise_error(@exception, msg)
+    end    
+    it "save method raises correct exception" do
+      project = TicketMaster::Provider::Tester::Project.new
+      msg = "TicketMaster::Provider::Tester::Project::save method must be implemented by the provider"
+      lambda { project.save }.should raise_error(@exception, msg)
+    end    
+    it "destroy method raises correct exception" do
+      project = TicketMaster::Provider::Tester::Project.new
+      msg = "TicketMaster::Provider::Tester::Project::destroy method must be implemented by the provider"
+      lambda { project.destroy }.should raise_error(@exception, msg)
+    end    
+  end
+  
+  describe "TicketMaster::Provider::Tester::Ticket" do
+    before(:each) do
+      @ticket = TicketMaster::Provider::Tester::Ticket.new(1)
+    end
+    it "find_by_id method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::find_by_id method must be implemented by the provider"
+      lambda { @ticketmaster.tickets(:id => 22) }.should raise_error(@exception, msg)
+    end    
+    it "find_by_attributes method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::find_by_attributes method must be implemented by the provider"
+      lambda { @ticketmaster.ticket.find(1, :all, :title => 'Test ticket') }.should raise_error(@exception, msg)
+    end    
+    it "search method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::search method must be implemented by the provider"
+      lambda { @ticketmaster.ticket.search :tag => 'testing' }.should raise_error(@exception, msg)
+    end    
+    it "create method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::create method must be implemented by the provider"
+      lambda { @ticketmaster.ticket.create :name => 'Foo Bar' }.should raise_error(@exception, msg)
+    end    
+    it "save method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::save method must be implemented by the provider"
+      lambda { @ticket.save }.should raise_error(@exception, msg)
+    end    
+    it "destroy method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::destroy method must be implemented by the provider"
+      lambda { @ticket.destroy }.should raise_error(@exception, msg)
+    end    
+    it "close method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::close method must be implemented by the provider"
+      lambda { @ticket.close }.should raise_error(@exception, msg)
+    end    
+    it "reload! method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Ticket::reload! method must be implemented by the provider"
+      lambda { @ticket.reload! }.should raise_error(@exception, msg)
+    end    
+  end
+  
+  describe "TicketMaster::Provider::Tester::Comment" do
+    before(:each) do
+      @ticket_with_comments = TicketMaster::Provider::Tester::Ticket.new(1)
+      @comment = TicketMaster::Provider::Tester::Comment.new(1, 1)
+    end
+    it "find_by_id method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::find_by_id method must be implemented by the provider"
+      lambda { @ticket_with_comments.comment.find(1, 1, [1,2]) }.should raise_error(@exception, msg)
+    end    
+    it "find_by_attributes method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::find_by_attributes method must be implemented by the provider"
+      lambda { @ticket_with_comments.comment.find(1, 1, :all, :tag => "tag") }.should raise_error(@exception, msg)
+    end    
+    it "search method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::search method must be implemented by the provider"
+      lambda { @ticket_with_comments.comment.search(1, 1, :tag => 'testing') }.should raise_error(@exception, msg)
+    end    
+    it "create method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::create method must be implemented by the provider"
+      lambda { @ticket_with_comments.comment.create :name => 'Foo Bar' }.should raise_error(@exception, msg)
+    end    
+    it "save method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::save method must be implemented by the provider"
+      lambda { @comment.save }.should raise_error(@exception, msg)
+    end    
+    it "destroy method raises correct exception" do
+      msg = "TicketMaster::Provider::Tester::Comment::destroy method must be implemented by the provider"
+      lambda { @comment.destroy }.should raise_error(@exception, msg)
+    end    
+  end
+
+end
+


### PR DESCRIPTION
While writing a provider, failing specs emitted cryptic messages. Here is an example:

Failures:
  1) Ticketmaster::Provider::Rally::Ticket should be able to load all tickets
     Failure/Error: @project.tickets.should be_an_instance_of(Array)
     This method must be reimplemented in the provider
     # ./spec/tickets_spec.rb:18

I've added reflection to all exception messages so, a provider author knows exactly which method to implement. Here is the spec failure with a new message:

Failures:
  1) Ticketmaster::Provider::Rally::Ticket should be able to load all tickets
     Failure/Error: @project.tickets.should be_an_instance_of(Array)
     TicketMaster::Provider::Rally::Ticket::find_by_attributes method must be implemented by the provider
     # ./spec/tickets_spec.rb:18

Thanks,
Simeon
