### PR TITLE
Ticket.find optimization

### DIFF
--- a/lib/ticketmaster/ticket.rb
+++ b/lib/ticketmaster/ticket.rb
@@ -61,6 +61,9 @@ module TicketMaster::Provider
           self.find_by_attributes(project_id)
         elsif first.is_a? Array
           first.collect { |id| self.find_by_id(project_id, id) }
+        # attributes has an :id key, so call Ticket.find_by_id
+        elsif !attributes.nil? and attributes.has_key?(:id)
+          self.find_by_id(project_id, attributes[:id])
         elsif first == :first
           tickets = attributes.nil? ? self.find_by_attributes(project_id) : self.find_by_attributes(project_id, attributes)
           tickets.first


### PR DESCRIPTION
For the Rally provider, this code's execution time kept exponentially increasing.

```
ticket = @project.ticket(:id => @ticket_id)
```

Project.ticket was calling Ticket.find an options argument which looked like this:

```
{:id => "2780205298"}
```

Therefore, Ticket.find_by_attributes was called. In the case of Rally, this method is much slower than Ticket.find_by_id. 

Instead of calling hash.has_key? in the Rally provider's Ticket.find_by_attributes and calling its Ticket.find_by_id, I thought it made more sense to move the logic up the inheritance chain to the base Ticket class. 

Thanks,
Simeon
