### PR TITLE
update examples to clarify the source accounts

### DIFF
--- a/examples/tm_example_3.rb
+++ b/examples/tm_example_3.rb
@@ -5,16 +5,17 @@ require 'ticketmaster-lighthouse'
 
 # copy all tickets and comments from pivotal tracker to new lighthouse project (the hard way)
 pivotal = TicketMaster.new(:pivotal)
-pivotal_project = pivotal.project(97107)
 lighthouse = TicketMaster.new(:lighthouse)
 
-lighthouse_project = lighthouse.project!(:name => "Copy Test on #{Time.now}", 
-                                         :description => "A copy test")
+from = pivotal.project(97107)
 
-pivotal_project.tickets.each do |pivotal_ticket|
-  lighthouse_ticket = lighthouse_project.ticket!({:title => pivotal_ticket.title, 
-                                                  :description => pivotal_ticket.description})
-  pivotal_ticket.comments.each do |comment|
-    lighthouse_ticket.comment!(:body => comment.body)
+to = lighthouse.project!(:name => "Copy Test on #{Time.now}", 
+                          :description => "A copy test")
+
+from.tickets.each do |from_ticket|
+  to_ticket = to.ticket!({:title => pivotal_ticket.title, 
+                          :description => pivotal_ticket.description})
+  from_ticket.comments.each do |comment|
+    to_ticket.comment!(:body => comment.body)
   end
 end

--- a/examples/tm_example_4.rb
+++ b/examples/tm_example_4.rb
@@ -5,11 +5,13 @@ require 'ticketmaster-lighthouse'
 
 # copy all tickets and comments from pivotal tracker to new lighthouse project (the easy way)
 pivotal = TicketMaster.new(:pivotal)
-pivotal_project = pivotal.project(97107)
 lighthouse = TicketMaster.new(:lighthouse)
 
-lighthouse_project = lighthouse.project!(:name => "Copy Test on #{Time.now}", 
-                                         :description => "A copy test")
-lighthouse_project.copy(pivotal_project)
+from = pivotal.project(97107)
+to = lighthouse.project!(:name => "Copy Test on #{Time.now}", 
+                          :description => "A copy test")
+                          
+to.copy(from)
+
 puts "Copy finished."
 


### PR DESCRIPTION
This ticket makes minor alterations to the example code to make changing the provider much easier.

My goal with these changes is to better highlight the ability that ticketmaster gives you to change the account providers.
