### PR TITLE
Switch to the new RSpec syntax

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -8,73 +8,120 @@ describe "Projects" do
   let(:project_class) { TaskMapper::Provider::Dummy::Project }
 
   describe "with a connection to a provider" do
-    context "when #projects" do
-      subject { tm.projects }
-      it { should be_an_instance_of Array }
-      it { subject.first.should be_an_instance_of project_class }
-      it { subject.last.should be_an_instance_of project_class }
+    describe "#projects" do
+      context "without arguments" do
+        let(:projects) { tm.projects }
+
+        it "is an array" do
+          expect(projects).to be_an Array
+        end
+
+        it "contains projects" do
+          expect(projects.first).to be_a project_class
+          expect(projects.last).to be_a project_class
+        end
+      end
+
+      context "with an ID argument" do
+        let(:project) { tm.projects(555) }
+
+        it "returns the requested project" do
+          expect(project).to be_a project_class
+          expect(project.id).to eq 555
+        end
+      end
+
+      context "with an array of IDs" do
+        let(:projects) { tm.projects([555]) }
+
+        it "returns an array of projects" do
+          expect(projects).to be_an Array
+        end
+
+        it "returns the requested projects" do
+          expect(projects.first).to be_a project_class
+          expect(projects.first.id).to eq 555
+        end
+      end
+
+      context "with a hash" do
+        let(:projects) { tm.projects(:id => 555) }
+
+        it "returns an array of projects" do
+          expect(projects).to be_an Array
+        end
+
+        it "returns the requested projects" do
+          expect(projects.first).to be_a project_class
+          expect(projects.first.id).to eq 555
+        end
+      end
+
+      describe "#first" do
+        let(:project) { tm.projects.first }
+
+        it "returns the requested project" do
+          expect(project.description).to_not be_nil
+          expect(project.description).to eq "Mock!-ing Bird"
+        end
+      end
     end
 
-    context "when #project with a hash is call" do
-      subject { tm.project(:name => "Whack whack what?") }
-      it { should be_an_instance_of project_class }
-      it { subject.name.should be_eql("Whack whack what?") }
-    end
+    describe "#project" do
+      context "without arguments" do
+        let(:project) { tm.project }
+        let(:first) { project.first }
+        let(:last) { project.last }
 
-    context "when retreiving a project" do
-      subject { tm.projects.first }
-      it { subject.description.should_not be_nil }
-      it { subject.description.should be_eql("Mock!-ing Bird") }
-    end
+        it "returns the project class" do
+          expect(project).to eq project_class
+        end
 
-    context "when #projects is call with an ID" do
-      subject { tm.projects(555) }
-      it { should be_an_instance_of project_class }
-      it { subject.id.should be_eql(555) }
-    end
+        it "contains the default items" do
+          expect(first.description).to eq "Mock!-ing Bird"
+          expect(last.description).to eq "Mock!-ing Bird"
+        end
+      end
 
-    context "when #projects is call with an array of IDs" do
-      subject { tm.projects([555]) }
-      it { should be_an_instance_of Array }
-      it { subject.first.should be_an_instance_of project_class }
-      it { subject.first.id.should be_eql(555) }
-    end
+      context "with a hash" do
+        let(:project) { tm.project(:name => "Whack whack what?") }
 
-    context "when #projects is call with a hash" do
-      subject { tm.projects(:id => 555) }
-      it { should be_an_instance_of Array }
-      it { subject.first.should be_an_instance_of project_class }
-      it { subject.first.id.should be_eql(555) }
-    end
+        it "returns the requested project" do
+          expect(project).to be_a project_class
+          expect(project.name).to eq "Whack whack what?"
+        end
+      end
 
-    context "when #project is call" do
-      subject { tm.project }
-      it { should be_eql project_class }
-      it { subject.first.description be_eql("Mock!-ing Bird") }
-      it { subject.last.description be_eql("Mock!-ing Bird") }
-    end
+      describe "#find" do
+        let(:project) { tm.project.find(:first, :description => "Shocking Dirb") }
 
-    context "when #project is call with a hash" do
-      subject { tm.project.find(:first, :description => "Shocking Dirb") }
-      it { should be_an_instance_of project_class }
-      it { subject.description.should be_eql("Shocking Dirb") }
-    end
-  end
+        it "returns the requested project" do
+          expect(project).to be_a project_class
+          expect(project.description).to eq "Shocking Dirb"
+        end
+      end
 
-  describe "declaring a new project" do
-    context "when calling #new" do
-      subject { tm.project.new(default_info) }
-      it { should be_an_instance_of project_class }
-      it { subject.name.should be_eql("Tiket Name  c") }
-      it { subject.save.should be_true }
-    end
-  end
+      describe "#new" do
+        let(:project) { tm.project.new(default_info) }
 
-  describe "creating a new project" do
-    context "when calling #create" do
-      subject { tm.project.create(default_info) }
-      it { should be_an_instance_of project_class }
-      it { subject.name.should be_eql("Tiket Name  c") }
+        it "returns a new project" do
+          expect(project).to be_a project_class
+          expect(project.name).to eq "Tiket Name  c"
+        end
+
+        it "persists the new project" do
+          expect(project.save).to be_true
+        end
+      end
+
+      describe "#create" do
+        let(:project) { tm.project.create(default_info) }
+
+        it "returns a new project" do
+          expect(project).to be_a project_class
+          expect(project.name).to eq "Tiket Name  c"
+        end
+      end
     end
   end
 

--- a/spec/taskmapper-exception_spec.rb
+++ b/spec/taskmapper-exception_spec.rb
@@ -11,16 +11,20 @@ describe "TaskMapper Exception Messages" do
   let(:easy_finder_error) { "TaskMapper::Provider::Helper::easy_finder method must be implemented by the provider" }
 
   describe TaskMapper::Provider::Base do
-    context "when calling #valid? method" do
-      subject { lambda { tm.valid? } }
-      it { should raise_error(exception, validation_error) }
+    describe "#valid?" do
+      it "has a custom exception message" do
+        expect{tm.valid?}.to raise_error(exception, validation_error)
+      end
     end
   end
 
   describe TaskMapper::Provider::Helper do
-    context "when calling #easy_finder" do
-      subject { lambda { tm.easy_finder(1, :test, {}) } }
-      it { should raise_error(exception, easy_finder_error) }
+    describe "#easy_finder" do
+      it "has a custom exception message" do
+        expect {
+          tm.easy_finder(1, :test, {})
+        }.to raise_error(exception, easy_finder_error)
+      end
     end
   end
 
@@ -32,35 +36,49 @@ describe "TaskMapper Exception Messages" do
     let(:save_error) { "TaskMapper::Provider::Tester::Project::save method must be implemented by the provider"}
     let(:destroy_error) { "TaskMapper::Provider::Tester::Project::destroy method must be implemented by the provider" }
 
-    context "when calling #find_by_id" do
-      subject { lambda { tm.project([1]) } }
-      it { should raise_error(exception, find_by_id_error) }
+    describe "#find_by_id" do
+      it "has a custom exception message" do
+        expect{tm.project([1])}.to raise_error(exception, find_by_id_error)
+      end
     end
 
-    context "when calling #find_by_attributes" do
-      subject { lambda { tm.project.find :all, :name => 'Test Project' } }
-      it { should raise_error(exception, find_by_attributes_error) }
+    describe "#find_by_attributes" do
+      it "has a custom exception message" do
+        expect {
+          tm.project.find :all, :name => 'Test Project'
+        }.to raise_error(exception, find_by_attributes_error)
+      end
     end
 
-    context "when calling #search" do
-      subject { lambda { tm.project.search :tag => 'testing' } }
-      it { should raise_error(exception, search_error) }
+    describe "#search" do
+      it "has a custom exception message" do
+        expect {
+          tm.project.search :tag => 'testing'
+        }.to raise_error(exception, search_error)
+      end
     end
 
-    context "when calling #create" do
-      subject { lambda { tm.project.create :name => 'Foo Bar' } }
-      it { should raise_error(exception, create_error) }
+    describe "#create" do
+      it "has a custom exception message" do
+        expect {
+          tm.project.create :name => 'Foo Bar'
+        }.to raise_error(exception, create_error)
+      end
     end
 
-    context "when calling #save" do
-      subject { lambda { tm.project.save } }
-      pending { should raise_error(exception, save_error) }
+    describe "#save" do
+      it "has a custom exception message" do
+        pending
+        expect{tm.project.save}.to raise_error(exception, save_error)
+      end
     end
 
-    context "when calling #destroy" do
+    describe "#destroy" do
       let(:project) { TaskMapper::Provider::Tester::Project.new }
-      subject { lambda { project.destroy } }
-      it { should raise_error(exception, destroy_error) }
+
+      it "has a custom exception message" do
+        expect{project.destroy}.to raise_error(exception, destroy_error)
+      end
     end
   end
 
@@ -75,44 +93,58 @@ describe "TaskMapper Exception Messages" do
     let(:close_error) { "TaskMapper::Provider::Tester::Ticket::close method must be implemented by the provider" }
     let(:reload_error) { "TaskMapper::Provider::Tester::Ticket::reload! method must be implemented by the provider" }
 
-    context "when #find_by_id" do
-      subject { lambda { tm.tickets(:id => 22) } }
-      it { should raise_error(exception, find_by_id_error) }
+    describe "#find_by_id" do
+      it "has a custom exception message" do
+        expect{tm.tickets(:id => 22)}.to raise_error(exception, find_by_id_error)
+      end
     end
 
-    context "when #find_by_attributes" do
-      subject { lambda { tm.ticket.find(1, :all, :title => 'Test ticket') } }
-      it { should raise_error(exception, find_by_attributes_error) }
+    describe "#find_by_attributes" do
+      it "has a custom exception message" do
+        expect {
+          tm.ticket.find(1, :all, :title => 'Test ticket')
+        }.to raise_error(exception, find_by_attributes_error)
+      end
     end
 
-    context "when #search" do
-      subject { lambda { tm.ticket.search :tag => 'testing' } }
-      it { should raise_error(exception, search_error) }
+    describe "#search" do
+      it "has a custom exception message" do
+        expect {
+          tm.ticket.search :tag => 'testing'
+        }.to raise_error(exception, search_error)
+      end
     end
 
-    context "when #create" do
-      subject { lambda { tm.ticket.create :name => 'Foo Bar' } }
-      it { should raise_error(exception, create_error) }
+    describe "#create" do
+      it "has a custom exception message" do
+        expect {
+          tm.ticket.create :name => 'Foo Bar'
+        }.to raise_error(exception, create_error)
+      end
     end
 
-    context "when #save" do
-      subject { lambda { ticket.save } }
-      it { should raise_error(exception, save_error) }
+    describe "#save" do
+      it "has a custom exception message" do
+        expect{ticket.save}.to raise_error(exception, save_error)
+      end
     end
 
-    context "when #destroy" do
-      subject { lambda { ticket.destroy } }
-      it { should raise_error(exception, destroy_error) }
+    describe "#destroy" do
+      it "has a custom exception message" do
+        expect{ticket.destroy}.to raise_error(exception, destroy_error)
+      end
     end
 
-    context "when #close" do
-      subject { lambda { ticket.close } }
-      it { should raise_error(exception, close_error) }
+    describe "#close" do
+      it "has a custom exception message" do
+        expect{ticket.close}.to raise_error(exception, close_error)
+      end
     end
 
-    context "when #reload!" do
-      subject { lambda { ticket.reload! } }
-      it { should raise_error(exception, reload_error) }
+    describe "#reload!" do
+      it "has a custom exception message" do
+        expect{ticket.reload!}.to raise_error(exception, reload_error)
+      end
     end
   end
 
@@ -126,34 +158,48 @@ describe "TaskMapper Exception Messages" do
     let(:save_error) { "TaskMapper::Provider::Tester::Comment::save method must be implemented by the provider" }
     let(:destroy_error) { "TaskMapper::Provider::Tester::Comment::destroy method must be implemented by the provider" }
 
-    context "when #find_by_id" do
-      subject { lambda { ticket_with_comments.comment.find(1,1,[1,2]) } }
-      it { should raise_error(exception, find_by_id_error) }
+    describe "#find_by_id" do
+      it "has a custom exception message" do
+        expect {
+          ticket_with_comments.comment.find(1,1,[1,2])
+        }.to raise_error(exception, find_by_id_error)
+      end
     end
 
-    context "when #find_by_attributes" do
-      subject { lambda { ticket_with_comments.comment.find(1, 1, :all, :tag => 'tag') } }
-      it { should raise_error(exception, find_by_attributes_error) }
+    describe "#find_by_attributes" do
+      it "has a custom exception message" do
+        expect {
+          ticket_with_comments.comment.find(1, 1, :all, :tag => 'tag')
+        }.to raise_error(exception, find_by_attributes_error)
+      end
     end
 
-    context "when #search" do
-      subject { lambda { ticket_with_comments.comment.search(1, 1, :tag => 'testing') } }
-      it { should raise_error(exception, search_error) }
+    describe "#search" do
+      it "has a custom exception message" do
+        expect {
+          ticket_with_comments.comment.search(1, 1, :tag => 'testing')
+        }.to raise_error(exception, search_error)
+      end
     end
 
-    context "when #create" do
-      subject { lambda { ticket_with_comments.comment.create :name => 'Foo Bar' } }
-      it { should raise_error(exception, create_error) }
+    describe "#create" do
+      it "has a custom exception message" do
+        expect{
+          ticket_with_comments.comment.create :name => 'Foo Bar'
+        }.to raise_error(exception, create_error)
+      end
     end
 
-    context "when #save" do
-      subject { lambda { comment.save } }
-      it { should raise_error(exception, save_error) }
+    describe "#save" do
+      it "has a custom exception message" do
+        expect{comment.save}.to raise_error(exception, save_error)
+      end
     end
 
-    context "when #destroy" do
-      subject { lambda { comment.destroy } }
-      it { should raise_error(exception, destroy_error) }
+    describe "#destroy" do
+      it "has a custom exception message" do
+        expect{comment.destroy}.to raise_error(exception, destroy_error)
+      end
     end
   end
 end

--- a/spec/taskmapper_spec.rb
+++ b/spec/taskmapper_spec.rb
@@ -4,9 +4,11 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 # Just replace the Dummy in @project_class and @ticket_class
 # Also, remember to mock or stub any API calls
 describe TaskMapper do
-  context "when calling new it should always return a taskmapper instance" do
-    subject { TaskMapper.new(:dummy, {}) }
-    it { should be_an_instance_of TaskMapper }
-    it { should be_a_kind_of TaskMapper::Provider::Dummy }
+  describe "#new" do
+    it "returns a TaskMapper instance" do
+      instance = TaskMapper.new :dummy, {}
+      expect(instance).to be_a TaskMapper
+      expect(instance).to be_a_kind_of TaskMapper::Provider::Dummy
+    end
   end
 end

--- a/spec/ticket_spec.rb
+++ b/spec/ticket_spec.rb
@@ -9,48 +9,62 @@ describe "Tickets" do
   let(:ticket_class) { TaskMapper::Provider::Dummy::Ticket }
   let(:project) { tm.projects.first }
 
-  describe "for a Project" do
-    context "when #tickets" do
-      subject { project.tickets }
-      it { should be_an_instance_of Array }
-      it { subject.first.should be_an_instance_of ticket_class }
+  describe "#tickets" do
+    context "without arguments" do
+      let(:tickets) { project.tickets }
+
+      it "returns an array of tickets" do
+        expect(tickets).to be_an Array
+        expect(tickets.first).to be_a ticket_class
+      end
     end
 
-    context "when searching wanting back all tickets that match the query" do
-      subject { project.tickets([999]) }
-      it { should be_an_instance_of Array }
-      it { subject.first.should be_an_instance_of ticket_class }
-      it { subject.first.id.should be_eql(999) }
+    context "with an array of IDs" do
+      let(:tickets) { project.tickets([999]) }
+      let(:ticket) { tickets.first }
+
+      it "returns an array of all matching tickets" do
+        expect(tickets).to be_a Array
+        expect(ticket).to be_a ticket_class
+        expect(ticket.id).to eq 999
+      end
     end
 
-    context "when passing an query hash" do
-      subject { project.tickets(:id => 999) }
-      it { should be_an_instance_of Array }
+    context "with a hash containing in ID" do
+      let(:tickets) { project.tickets(:id => 999) }
+      let(:ticket) { tickets.first }
+
+      it "returns an array of all matching tickets" do
+        expect(tickets).to be_a Array
+        expect(ticket).to be_a ticket_class
+        expect(ticket.id).to eq 999
+      end
+    end
+  end
+
+  describe "#ticket" do
+    context "without arguments" do
+      it "returns the ticket class" do
+        expect(project.ticket).to eq ticket_class
+      end
     end
 
-    context "when searching wanting back the first ticket that matches the query" do
-      subject { project.ticket }
-      it { should be_eql TaskMapper::Provider::Dummy::Ticket }
+    context "with an ID" do
+      let(:ticket) { project.ticket(888) }
+
+      it "returns the requested ticket" do
+        expect(ticket).to be_a ticket_class
+        expect(ticket.id).to eq 888
+      end
     end
 
-    context "when querying using default ID query" do
-      subject { project.ticket(888) }
-      it { should be_an_instance_of ticket_class }
-    end
+    context "with an hash containing an ID" do
+      let(:ticket) { project.ticket(:id => 888) }
 
-    context "when passing an id to #ticket" do
-      subject { project.ticket(888) }
-      it { subject.id.should be_eql(888) }
-    end
-
-    context "when passing a hash to #ticket" do
-      subject { project.ticket(:id => 888) }
-      it { should be_an_instance_of ticket_class }
-    end
-
-    context "when passing an id to #ticket" do
-      subject { project.ticket(888) }
-      it { subject.id.should be_eql(888) }
+      it "returns the requested ticket" do
+        expect(ticket).to be_a ticket_class
+        expect(ticket.id).to eq 888
+      end
     end
   end
 end


### PR DESCRIPTION
Switches to new RSpec syntax, and improves readability/wording of some specs. Also removes some unnecessary duplication of specs.
